### PR TITLE
Add dev server support

### DIFF
--- a/docs/customizing/configuration.mdx
+++ b/docs/customizing/configuration.mdx
@@ -65,6 +65,26 @@ export default {
 } satisfies MagnitudeConfig;
 ```
 
+## Development web server
+
+Magnitude can automatically launch your development server when tests run. Configure `webServer` with the command to start the server and the URL it will listen on:
+
+```typescript
+import { type MagnitudeConfig } from 'magnitude-test';
+
+export default {
+    url: 'http://localhost:3000',
+    webServer: {
+        command: 'npm run start',
+        url: 'http://localhost:3000',
+        timeout: 120_000,
+        reuseExistingServer: true
+    }
+} satisfies MagnitudeConfig;
+```
+
+Magnitude checks if `webServer.url` is already reachable. If so and `reuseExistingServer` is `true`, the command is skipped. The server process is killed automatically once the test run completes.
+
 ## Test URL resolution
 
 Each test uses a URL that is built from the broader scope of configuration in this order:

--- a/packages/magnitude-test/README.md
+++ b/packages/magnitude-test/README.md
@@ -60,25 +60,6 @@ npx magnitude
 ```
 This will run all Magnitude test files discovered with the `*.mag.ts` pattern.
 
-### Automatically start your dev server
-
-Add a `webServer` section in `magnitude.config.ts` to have Magnitude start your development server when tests run:
-
-```ts
-import { defineConfig } from 'magnitude-test';
-
-export default defineConfig({
-    baseUrl: 'http://localhost:3000',
-    webServer: {
-        command: 'npm run start',
-        url: 'http://localhost:3000',
-        reuseExistingServer: true
-    }
-});
-```
-
-Magnitude checks if the server is already running and skips the command when `reuseExistingServer` is `true`.
-
 Here's an example of a basic test case:
 ```ts
 // tests/example.mag.ts

--- a/packages/magnitude-test/README.md
+++ b/packages/magnitude-test/README.md
@@ -60,6 +60,25 @@ npx magnitude
 ```
 This will run all Magnitude test files discovered with the `*.mag.ts` pattern.
 
+### Automatically start your dev server
+
+Add a `webServer` section in `magnitude.config.ts` to have Magnitude start your development server when tests run:
+
+```ts
+import { defineConfig } from 'magnitude-test';
+
+export default defineConfig({
+    baseUrl: 'http://localhost:3000',
+    webServer: {
+        command: 'npm run start',
+        url: 'http://localhost:3000',
+        reuseExistingServer: true
+    }
+});
+```
+
+Magnitude checks if the server is already running and skips the command when `reuseExistingServer` is `true`.
+
 Here's an example of a basic test case:
 ```ts
 // tests/example.mag.ts

--- a/packages/magnitude-test/src/cli.ts
+++ b/packages/magnitude-test/src/cli.ts
@@ -22,6 +22,7 @@ import { execSync } from 'child_process';
 import { TestRunner } from './runner/testRunner'; // Import the new executor
 import { initializeTestStates } from './term-app/util';
 import { initializeUI, updateUI, cleanupUI } from '@/term-app'; // Import term-app functions
+import { startWebServer, stopWebServer } from './webServer';
 import chalk from 'chalk';
 
 interface CliOptions {
@@ -231,6 +232,19 @@ program
 
         logger.info({ ...config.executor }, "Executor:");
         //console.log(magnitudeBlue(`Using executor: ${config.executor.provider}`));
+
+        let webServerProcess: import('node:child_process').ChildProcess | null = null;
+        if (config.webServer) {
+            try {
+                webServerProcess = await startWebServer(config.webServer);
+                const cleanup = () => stopWebServer(webServerProcess);
+                process.on('exit', cleanup);
+                process.on('SIGINT', () => { cleanup(); process.exit(1); });
+            } catch (err) {
+                console.error('Error starting web server:', err);
+                process.exit(1);
+            }
+        }
 
 
 

--- a/packages/magnitude-test/src/discovery/types.ts
+++ b/packages/magnitude-test/src/discovery/types.ts
@@ -6,11 +6,19 @@ export interface TestOptions {
     //name?: string;
 }
 
+export interface WebServerConfig {
+    command: string;
+    url: string;
+    timeout?: number;
+    reuseExistingServer?: boolean;
+}
+
 export type MagnitudeConfig = {
     //apiKey?: string;
     url: string; // base URL used as default, required
     planner?: PlannerClient,
     executor?: ExecutorClient,
+    webServer?: WebServerConfig,
     browser?: {
         contextOptions?: BrowserContextOptions,
         launchOptions?: LaunchOptions

--- a/packages/magnitude-test/src/index.ts
+++ b/packages/magnitude-test/src/index.ts
@@ -1,4 +1,4 @@
 // Needed for React to work properly
 process.env.NODE_ENV = process.env.NODE_ENV || 'production';
 export { test } from '@/discovery/testDeclaration';
-export { type MagnitudeConfig } from '@/discovery/types';
+export { type MagnitudeConfig, type WebServerConfig } from '@/discovery/types';

--- a/packages/magnitude-test/src/webServer.ts
+++ b/packages/magnitude-test/src/webServer.ts
@@ -1,0 +1,39 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { setTimeout as delay } from 'node:timers/promises';
+import { WebServerConfig } from './discovery/types';
+
+export async function isServerRunning(url: string): Promise<boolean> {
+    try {
+        const res = await fetch(url, { method: 'HEAD' });
+        return !!res.ok || res.status >= 200; // any response indicates server
+    } catch {
+        return false;
+    }
+}
+
+export async function startWebServer(config: WebServerConfig): Promise<ChildProcess | null> {
+    const { command, url, timeout = 60_000, reuseExistingServer = false } = config;
+
+    if (reuseExistingServer && await isServerRunning(url)) {
+        return null;
+    }
+
+    const child = spawn(command, { shell: true, stdio: 'inherit' });
+
+    const startTime = Date.now();
+    while (Date.now() - startTime < timeout) {
+        if (await isServerRunning(url)) {
+            return child;
+        }
+        await delay(500);
+    }
+
+    child.kill();
+    throw new Error(`Timed out waiting for web server at ${url}`);
+}
+
+export function stopWebServer(proc: ChildProcess | null | undefined): void {
+    if (proc) {
+        proc.kill();
+    }
+}


### PR DESCRIPTION
## Summary
- add `webServer` option to `MagnitudeConfig`
- launch dev server from CLI when configured
- document webServer option in README and docs

## Testing
- `bun run build` *(fails: cannot find module 'typescript')*